### PR TITLE
Fix funky manifest argument fetching

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,8 +3,6 @@
 PKG_DEPENDENCIES="sqlite3 libldap2-dev libsasl2-dev python3-dev imagemagick python3-lxml libjpeg-dev"
 #PKG_DEPENDENCIES="sqlite3 python3-pip imagemagick"
 DOSSIER_MEDIA=/home/yunohost.multimedia
-LOG_FILE=/var/log/$app/$app.log
-ACCESS_LOG_FILE=/var/log/$app/$app-access.log
 
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -6,30 +6,27 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
+app=$YNH_APP_INSTANCE_NAME
+
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 admin=$YNH_APP_ARG_ADMIN
 is_public=$YNH_APP_ARG_IS_PUBLIC
 language=$YNH_APP_ARG_LANGUAGE
-app=$YNH_APP_INSTANCE_NAME
-upload=$6
-public_library=$7
+upload=$YNH_APP_ARG_UPLOAD
+public_library=$7YNH_APP_ARG_PUBLIC_LIBRARY
+
 #if app is public, we assume library is public
 if [ $is_public -eq 1 ]; then
 	public_library=1
 fi
-source _common.sh
-
-
-
-source _common.sh
-source /usr/share/yunohost/helpers
 
 #=================================================
 # MANAGE SCRIPT FAILURE

--- a/scripts/install
+++ b/scripts/install
@@ -28,6 +28,9 @@ if [ $is_public -eq 1 ]; then
 	public_library=1
 fi
 
+LOG_FILE=/var/log/$app/$app.log
+ACCESS_LOG_FILE=/var/log/$app/$app-access.log
+
 #=================================================
 # MANAGE SCRIPT FAILURE
 #=================================================


### PR DESCRIPTION
I'm about to push a change in package_linter that's gonna report an error if you fetch manifest argument using "$foobar=$N" and noticed some funky stuff happening in this install script ...