### PR TITLE
Port shouldn't be opened on the firewall ... it supposed to be only for reverse proxying

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding//conf/generate_password_hash.py=utf-8

--- a/scripts/install
+++ b/scripts/install
@@ -67,14 +67,13 @@ ynh_app_setting_set $app is_public $is_public
 #=================================================
 # STANDARD MODIFICATIONS
 #=================================================
-# FIND AND OPEN A PORT
+# FIND AN AVAILABLE PORT
 #=================================================
 
 # Find a free port
 port=$(ynh_find_port 8083)
 # Open this port
 ynh_script_progression --message="Opening port $port..." --weight=5
-yunohost firewall allow --no-upnp TCP $port 2>&1
 ynh_app_setting_set $app port $port
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -72,8 +72,7 @@ ynh_app_setting_set $app is_public $is_public
 
 # Find a free port
 port=$(ynh_find_port 8083)
-# Open this port
-ynh_script_progression --message="Opening port $port..." --weight=5
+ynh_script_progression --message="Setting port $port..." --weight=5
 ynh_app_setting_set $app port $port
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -51,7 +51,6 @@ ynh_restore_file "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_script_progression --message="reopening port $port..." --weight=5
-yunohost firewall allow --no-upnp TCP $port 2>&1
 ynh_app_setting_set $app port $port
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -59,7 +59,7 @@ fi
 #Close unwanted open port in firewall
 if yunohost firewall list | grep -q "\- $port$"
 then
-	ynh_script_progression --message="Closing port $port..." --weight=10
+	ynh_script_progression --message="Closing port $port as it shouldn't be open..."
 	yunohost firewall disallow TCP $port 2>&1
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -56,6 +56,14 @@ else #on est encore en 0.6.0
 	current_upstream_app_version='0.6.0' 
 fi
 
+#Close unwanted open port in firewall
+if yunohost firewall list | grep -q "\- $port$"
+then
+	ynh_script_progression --message="Closing port $port..." --weight=10
+	yunohost firewall disallow TCP $port 2>&1
+fi
+
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================


### PR DESCRIPTION
as reported by https://forum.yunohost.org/t/redirection-automatique-ip-port/12714

c.f. https://github.com/YunoHost/issues/issues/1487

This is an obvious security risk >_>

N.B. : this PR was only made on the install script, probably similar stuff to do in upgrade and restore ... in particular not forgetting to close the port on existing installs during upgrade ...