### PR TITLE
Grant access to multimedia folder when restoring

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -84,7 +84,7 @@
                 "optional": true,
                 "ask": {
                     "en": "Do you want to allow uploading of books?",
-                    "fr": "Voulez vous autoriser l'upload de livres?"
+                    "fr": "Voulez vous autoriser le téléversement de livres?"
                 },
                 "help":{
                 	"en":"You may change it later in the app",

--- a/scripts/restore
+++ b/scripts/restore
@@ -66,6 +66,7 @@ ynh_script_progression --message="Recreating the dedicated system user..." --wei
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app
 
+
 #=================================================
 # RESTORE THE APP MAIN DIR
 #=================================================
@@ -81,6 +82,7 @@ ynh_restore_file --origin_path="$final_path"
 chown -R $app: $final_path
 
 #=================================================
+
 # SPECIFIC RESTORATION
 #=================================================
 # REINSTALL DEPENDENCIES
@@ -127,25 +129,37 @@ chown -R $app:$app /var/log/$app
 # RESTORE THE DATA DIRECTORY
 #=================================================
 
-ynh_script_progression --message="Restoring data directory..." --weight=2
+ynh_script_progression --message="Restoring data directory if required..." --weight=2
 # The data directory will be restored only if it exists in the backup archive
 # So only if it was backup previously.
-
-if [ -d "$YNH_BACKUP_DIR/apps/$app/backup/$calibre_dir" ]
-then
+#if [ -d "$YNH_BACKUP_DIR/apps/$app/backup/$calibre_dir" ] && [ ! tail "$calibre_dir" | grep "yunohost.multimedia" ]; then
 	ynh_restore_file --origin_path="$calibre_dir" --not_mandatory
-else
-	if [ ! -e "$calibre_dir" ]; then
-		ynh_print_info "Create calibre library folder $calibre_dir"
-		mkdir -p $calibre_dir
-		chown -R $app:$app $calibre_dir
-	fi
-#Check if metadata.db file exists. If not create it (empty library)
-	if [ ! -e "$calibre_dir"/metadata.db ]; then
-		cp -a ../settings/conf/metadata.db.empty $calibre_dir/metadata.db
-		chown $app:$app $calibre_dir/*
-	fi
+#fi
+
+#=================================================
+# RESTORE THE MULTIMEDIA DIR IF NOT EXISTING
+#=================================================
+ynh_script_progression --message="Restoring the multimedia directory..." --weight=5
+ynh_multimedia_build_main_dir
+ynh_multimedia_addaccess $app
+
+#=================================================
+# INITIALIZE DATA IF NOT EXISTING
+#=================================================
+
+if [ ! -e "$calibre_dir" ]; then
+	ynh_print_info "Create calibre library folder $calibre_dir"
+	mkdir -p $calibre_dir
+	chown -R $app:$app $calibre_dir
 fi
+#Check if metadata.db file exists. If not create it (empty library)
+if [ ! -e "$calibre_dir"/metadata.db ]; then
+	cp -a ../settings/conf/metadata.db.empty $calibre_dir/metadata.db
+	chown $app:$app $calibre_dir/*
+fi
+
+
+
 
 #Update Imagick policy as per https://github.com/janeczku/calibre-web/wiki/FAQ#what-to-do-if-cover-pictures-are-not-extracted-from-pdf-files
 ynh_replace_string --match_string="<policy domain="coder" rights="none" pattern="PDF" />" \

--- a/scripts/restore
+++ b/scripts/restore
@@ -66,23 +66,18 @@ ynh_script_progression --message="Recreating the dedicated system user..." --wei
 # Create the dedicated user (if not existing)
 ynh_system_user_create --username=$app
 
-
 #=================================================
 # RESTORE THE APP MAIN DIR
 #=================================================
 ynh_script_progression --message="Restoring the app main directory..." --weight=1
-
 ynh_restore_file --origin_path="$final_path"
 
 #=================================================
 # RESTORE USER RIGHTS
 #=================================================
-
-# Restore permissions on app files
 chown -R $app: $final_path
 
 #=================================================
-
 # SPECIFIC RESTORATION
 #=================================================
 # REINSTALL DEPENDENCIES
@@ -158,9 +153,9 @@ if [ ! -e "$calibre_dir"/metadata.db ]; then
 	chown $app:$app $calibre_dir/*
 fi
 
-
-
-
+#===================================================
+# SPECIFIC SETUP
+#===================================================
 #Update Imagick policy as per https://github.com/janeczku/calibre-web/wiki/FAQ#what-to-do-if-cover-pictures-are-not-extracted-from-pdf-files
 ynh_replace_string --match_string="<policy domain="coder" rights="none" pattern="PDF" />" \
 		--replace_string="<policy domain="coder" rights="read" pattern="PDF" />" \


### PR DESCRIPTION
## Problem
- *When restoring, access to multimedia folder were not granted to calibreweb user*

## Solution
- *reinstate ynh helper for multimedia folders*

## PR Status
- [X] Code finished.
- [x] Tested with Package_check.
- [X] Fix or enhancement tested.
- [X] Upgrade from last version tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/calibreweb_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/calibreweb_ynh%20PR-NUM-%20(USERNAME)/)  
