### PR TITLE
Add Kobo Sync info in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ chmod o+rw path/to/library
 * Do not use a Nextcloud folder. It's all right if the folder is an external storage in Nextcloud but not if it's an internal one : Changing the data in the library will cause trouble with the sync
 * "Magic link feature is not yet available
 * Change to library made outside calibreweb are not automatically updated in calibreweb. It is required to disconnect and reconnect to see the changes : Do not open a database both in calibre & calibreweb!
-
+* Kobo Sync doesn’t work when Calibre is installed on a subdomain. This issue is caused by nginx. However, it works great when installed on a path e.g. `https://domain.tld/calibreweb`
 
 ## Links
 


### PR DESCRIPTION
## Problem

- I’ve tried to use kobo sync when Calibre-Web is installed on a subdomain. Sync worked, but I was not able to download any of my books.
- I’ve then changed the configuration in nginx to allow `proxy_set_header	X-Script-Name __PATH__;`. Syncing and downloading worked then, but I could’nt access Calibre-Web on a browser anymore : there was a `too many rederict` problem.
- I’ve reinstalled Calibre-Web in a subpath, everything worked flawlessly.


## Solution

- Add the limitation in the Readme. 


Thanks for this awesome packaging !! I’m very happy to see such app on Yunohost !!