### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,7 +82,7 @@ if [ -z $(sqlite3 $install_dir/app.db "SELECT config_kepubifypath FROM settings"
 	eval sqlite3 $install_dir/app.db "\"UPDATE settings SET config_kepubifypath='/opt/kepubify/$app/kepubify' WHERE ID=1\""
 fi
 if [ ! -d /opt/kepubify/$app ]; then
-	ynh_setup_source --dest_dir="/opt/kepubify/$app" --source_id="kepubify"
+	ynh_setup_source --dest_dir="/opt/kepubify/$app" --source_id="kepubify" --full_replace=1
 	chmod 770 /opt/kepubify/$app/kepubify
 fi
 
@@ -109,7 +109,7 @@ then
 	ynh_add_config --template="../sources/patches/main-constants.py.patch.src" --destination="../sources/patches/main-constants.py.patch"
 	
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$install_dir"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1
 	chown -R $app: $install_dir
 	
 	# Remove the patch for web.py in case visitor are allowed


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```