### PR TITLE
Enable x-script-name when on subdomain

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Calibre-web"
 description.en = "Browsing, reading and downloading eBooks using a Calibre database"
 description.fr = "Explorer, lire et télécharger des eBooks à partir d'une base de données Calibre"
 
-version = "0.96.24~ynh1"
+version = "0.96.24~ynh2"
 
 maintainers = ["Krakinou"]
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -30,7 +30,7 @@ ynh_systemd_action --service_name=$app --action="stop"
 ynh_script_progression --message="Updating NGINX web server configuration..." --weight=1
 #Cannot use empty string for X-script-name, causes an issue in the python prg
 if [ $new_path = "/" ] ; then
-	ynh_replace_string "        proxy_set_header	X-Script-Name" "#       proxy_set_header	X-Script-Name" ../conf/nginx.conf
+	ynh_replace_string "        proxy_set_header	X-Script-Name		__PATH__;" "proxy_set_header	X-Script-Name		__PATH__/;" ../conf/nginx.conf
 else
 	ynh_replace_string "#       proxy_set_header	X-Script-Name" "        proxy_set_header	X-Script-Name" ../conf/nginx.conf
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -96,7 +96,7 @@ ynh_script_progression --message="Setting up system configuration..." --weight=5
 #Cannot use empty string for X-script-name, causes an issue in the python prg
 #https://github.com/janeczku/calibre-web/wiki/Setup-Reverse-Proxy#nginx
 if [ $path = "/" ] ; then
-	ynh_replace_string "        proxy_set_header	X-Script-Name" "#        proxy_set_header	X-Script-Name" ../conf/nginx.conf
+	ynh_replace_string "        proxy_set_header	X-Script-Name		__PATH__;" "proxy_set_header	X-Script-Name		__PATH__/;" ../conf/nginx.conf
 fi
 
 #

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -127,7 +127,7 @@ ynh_script_progression --message="Upgrading nginx web server configuration..." -
 #Cannot use empty string for X-script-name, causes an issue in the python prg
 #https://github.com/janeczku/calibre-web/wiki/Setup-Reverse-Proxy#nginx
 if [ $path = "/" ] ; then
-	ynh_replace_string "        proxy_set_header	X-Script-Name" "#       proxy_set_header	X-Script-Name" ../conf/nginx.conf
+	ynh_replace_string "        proxy_set_header	X-Script-Name		__PATH__;" "proxy_set_header	X-Script-Name		__PATH__/;" ../conf/nginx.conf
 fi
 
 #Setting the proxy authentication in case calibre is not open to visitor.


### PR DESCRIPTION
## Problem

- *Description of why you made this PR*
It’s currently not possible to use Kobo sync integration on (sub)domain because of lacking X-SCRIPT-NAME in NGINX.

## Solution

https://github.com/janeczku/calibre-web/issues/1470#issuecomment-1598573637
Adding a trailing slash more fixes the issue. I’ve tested and works.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
